### PR TITLE
Added Kotlin Named Argument Color

### DIFF
--- a/src/main/resources/themes/Dracula.xml
+++ b/src/main/resources/themes/Dracula.xml
@@ -1006,6 +1006,11 @@
         <option name="FOREGROUND" value="8be9fd" />
       </value>
     </option>
+    <option name="KOTLIN_NAMED_ARGUMENT">
+      <value>
+        <option name="FOREGROUND" value="6272a4" />
+      </value>
+    </option>
     <option name="List/map to object conversion">
       <value />
     </option>


### PR DESCRIPTION
Kotlin didn't have a great color for Named Arguments. Updated to [Dracula's Color Palette](https://github.com/dracula/dracula-theme#color-palette) (Comment)

Old: `#467CDA`
![image](https://user-images.githubusercontent.com/12074633/70820672-3db16000-1da7-11ea-8950-46768f874b90.png)

New: `#6272A4`
![image](https://user-images.githubusercontent.com/12074633/70820691-49048b80-1da7-11ea-82f1-84862d263461.png)
