### PR TITLE
:art: Add alucard light theme prototype

### DIFF
--- a/src/main/kotlin/com/draculatheme/jetbrains/enums/DraculaVariant.kt
+++ b/src/main/kotlin/com/draculatheme/jetbrains/enums/DraculaVariant.kt
@@ -1,5 +1,5 @@
 package com.draculatheme.jetbrains.enums
 
 enum class DraculaVariant(val label: String) {
-    Dracula("Dracula"), DraculaColorful("Dracula Colorful")
+    Dracula("Dracula"), DraculaColorful("Dracula Colorful"), DraculaAlucard("Dracula Alucard")
 }

--- a/src/main/kotlin/com/draculatheme/jetbrains/listeners/DraculaThemeChangeListener.kt
+++ b/src/main/kotlin/com/draculatheme/jetbrains/listeners/DraculaThemeChangeListener.kt
@@ -14,7 +14,7 @@ class DraculaThemeChangeListener : LafManagerListener {
     override fun lookAndFeelChanged(lafManager: LafManager) {
         val currentUI = lafManager.currentUIThemeLookAndFeel.name
         if (previousUI != currentUI) {
-            if (currentUI == DraculaVariant.Dracula.label || currentUI == DraculaVariant.DraculaColorful.label) {
+            if (currentUI == DraculaVariant.Dracula.label || currentUI == DraculaVariant.DraculaColorful.label || currentUI == DraculaVariant.DraculaAlucard.label) {
                 editorColorsManager.setGlobalScheme(editorColorsManager.getScheme("_@user_$currentUI"))
             }
         }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -10,6 +10,7 @@
         <notificationGroup displayType="STICKY_BALLOON" id="Dracula Theme" isLogByDefault="true"/>
         <themeProvider id="371dce76-a3c5-4429-91af-41cf86094744" path="/themes/Dracula.theme.json"/>
         <themeProvider id="ee2824b3-c1d9-44fa-8b64-de6fe5dd8e37" path="/themes/DraculaColorful.theme.json"/>
+        <themeProvider id="f8c76d9a-2c8d-4e4f-a327-d7b5c1ce6d3e" path="/themes/DraculaAlucard.theme.json"/>
     </extensions>
     <applicationListeners>
         <listener class="com.draculatheme.jetbrains.listeners.DraculaThemeChangeListener"

--- a/src/main/resources/themes/Dracula.xml
+++ b/src/main/resources/themes/Dracula.xml
@@ -3,7 +3,7 @@
     <option name="ADDED_LINES_COLOR" value="48b764" />
     <option name="ANNOTATIONS_COLOR" value="f8f8f2" />
     <option name="CARET_COLOR" value="cccccc" />
-    <option name="CARET_ROW_COLOR" value="44475a" />
+    <option name="CARET_ROW_COLOR" value="3a3d4c" />
     <option name="CONSOLE_BACKGROUND_KEY" value="282a36" />
     <option name="DELETED_LINES_COLOR" value="cd4644" />
     <option name="DOCUMENTATION_COLOR" value="3a3d4c" />
@@ -19,7 +19,7 @@
     <option name="FILESTATUS_IDEA_SVN_FILESTATUS_EXTERNAL" value="ffb86c" />
     <option name="FILESTATUS_IDEA_SVN_FILESTATUS_OBSTRUCTED" value="f1fa8c" />
     <option name="FILESTATUS_IDEA_SVN_REPLACED" value="50fa7b" />
-    <option name="FILESTATUS_IGNORE.PROJECT_VIEW.IGNORED" value="808080" />
+    <option name="FILESTATUS_IGNORE.PROJECT_VIEW.IGNORED" value="9a9a9a" />
     <option name="FILESTATUS_MERGED" value="bd93f9" />
     <option name="FILESTATUS_MODIFIED" value="8be9fd" />
     <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="8be9fd" />
@@ -41,8 +41,8 @@
     <option name="SELECTED_TEARLINE_COLOR" value="a8b0e2" />
     <option name="SEPARATOR_ABOVE_COLOR" value="6b7090" />
     <option name="SEPARATOR_BELOW_COLOR" value="6b7090" />
-    <option name="ScrollBar.Mac.hoverThumbColor" value="bd93f9" />
-    <option name="ScrollBar.Mac.thumbColor" value="bd93f983" />
+    <option name="ScrollBar.Mac.hoverThumbColor" value="3a3d4c" />
+    <option name="ScrollBar.Mac.thumbColor" value="3a3d4c83" />
     <option name="TEARLINE_COLOR" value="6b7090" />
     <option name="VCS_ANNOTATIONS_COLOR_1" value="8d64b0" />
     <option name="VCS_ANNOTATIONS_COLOR_2" value="c6538d" />

--- a/src/main/resources/themes/DraculaAlucard.theme.json
+++ b/src/main/resources/themes/DraculaAlucard.theme.json
@@ -1,19 +1,19 @@
 {
-  "name": "Dracula",
-  "dark": true,
+  "name": "Dracula Alucard",
+  "dark": false,
   "author": "Zihan Ma",
-  "editorScheme": "/themes/Dracula.xml",
+  "editorScheme": "/themes/DraculaAlucard.xml",
   "colors": {
-    "accentColor": "#ff79c6",
-    "secondaryAccentColor": "#3a3d4c",
-    "primaryForeground": "#f8f8f2",
-    "primaryBackground": "#414450",
-    "secondaryBackground": "#3a3d4c",
-    "hoverBackground": "#282a36",
-    "selectionBackground": "#6272a4",
-    "selectionInactiveBackground": "#4e5a82",
-    "borderColor": "#282a36",
-    "separatorColor": "#5d5e66"
+    "accentColor": "#a3144d",
+    "secondaryAccentColor": "#dedccf",
+    "primaryForeground": "#1f1f1f",
+    "primaryBackground": "#ece9df",
+    "secondaryBackground": "#dedccf",
+    "hoverBackground": "#fffbeb",
+    "selectionBackground": "#cfcfde",
+    "selectionInactiveBackground": "#bcbab3",
+    "borderColor": "#fffbeb",
+    "separatorColor": "#bcbab3"
   },
   "ui": {
     "*": {
@@ -45,34 +45,34 @@
       },
       "MnemonicAssigned": {
         "foreground": "primaryForeground",
-        "background": "#786299"
+        "background": "#7862d0"
       },
       "MnemonicCurrent": {
         "foreground": "primaryForeground",
-        "background": "#8d6b81"
+        "background": "#bf185a"
       }
     },
     "Button": {
       "foreground": "primaryForeground",
       "startBorderColor": "selectionBackground",
       "endBorderColor": "selectionBackground",
-      "startBackground": "#4f566d",
-      "endBackground": "#4f566d",
+      "startBackground": "#efeddc",
+      "endBackground": "#efeddc",
       "focusedBorderColor": "secondaryAccentColor",
-      "disabledBorderColor": "#4f566d",
+      "disabledBorderColor": "#efeddc",
       "default": {
         "foreground": "primaryForeground",
         "startBackground": "selectionBackground",
         "endBackground": "selectionBackground",
-        "startBorderColor": "secondaryAccentColor",
-        "endBorderColor": "secondaryAccentColor",
+        "startBorderColor": "#644ac9",
+        "endBorderColor": "#644ac9",
         "focusColor": "secondaryAccentColor",
         "focusedBorderColor": "secondaryAccentColor"
       }
     },
     "Counter": {
       "foreground": "primaryBackground",
-      "background": "#2fc864"
+      "background": "#14710a"
     },
     "CheckBoxMenuItem": {
       "acceleratorSelectionForeground": "accentColor"
@@ -82,7 +82,7 @@
       "ArrowButton": {
         "background": "secondaryBackground",
         "nonEditableBackground": "secondaryBackground",
-        "disabledIconColor": "#576285",
+        "disabledIconColor": "#6c664b",
         "iconColor": "secondaryAccentColor"
       },
       "selectionBackground": "secondaryAccentColor",
@@ -98,10 +98,10 @@
       "borderColor": "selectionBackground",
       "focusedBorderColor": "selectionBackground",
       "disabledBorderColor": "selectionBackground",
-      "errorFocusColor": "#ff5554",
-      "inactiveErrorFocusColor": "#ff5554",
-      "warningFocusColor": "#f1fa8c",
-      "inactiveWarningFocusColor": "#f1fa8c"
+      "errorFocusColor": "#cb3a2a",
+      "inactiveErrorFocusColor": "#cb3a2a",
+      "warningFocusColor": "#846e15",
+      "inactiveWarningFocusColor": "#846e15"
     },
     "DragAndDrop": {
       "borderColor": "selectionBackground"
@@ -112,20 +112,20 @@
     },
     "EditorTabs": {
       "background": "secondaryBackground",
-      "underlinedTabBackground": "#292b38",
+      "underlinedTabBackground": "#fffbeb",
       "underlineColor": "secondaryAccentColor",
       "underlineHeight": 2
     },
     "FileColor": {
-      "Blue": "#344f54",
-      "Green": "#344535",
-      "Orange": "#533f30",
-      "Yellow": "#4f4b41",
-      "Rose": "#4c273c",
-      "Violet": "#382b4a"
+      "Blue": "#d4e5ec",
+      "Green": "#d4e8d5",
+      "Orange": "#ece0d4",
+      "Yellow": "#e8e6dc",
+      "Rose": "#e8d4dd",
+      "Violet": "#dbd4e6"
     },
     "Label": {
-      "errorForeground": "#ff5554"
+      "errorForeground": "#cb3a2a"
     },
     "Link": {
       "activeForeground": "accentColor",
@@ -135,19 +135,19 @@
     },
     "Notification": {
       "borderColor": "selectionBackground",
-      "errorBorderColor": "#ff5554",
+      "errorBorderColor": "#cb3a2a",
       "errorBackground": "primaryBackground",
       "errorForeground": "primaryForeground",
       "ToolWindow": {
         "warningForeground": "primaryForeground",
         "warningBackground": "primaryBackground",
-        "warningBorderColor": "#ffb86c",
+        "warningBorderColor": "#a34d14",
         "errorForeground": "primaryForeground",
-        "errorBorderColor": "#ff5554",
+        "errorBorderColor": "#cb3a2a",
         "errorBackground": "primaryBackground",
         "informativeForeground": "primaryForeground",
         "informativeBackground": "primaryBackground",
-        "informativeBorderColor": "#50fa7b"
+        "informativeBorderColor": "#14710a"
       }
     },
     "NotificationsToolwindow": {
@@ -178,9 +178,9 @@
         "installFillForeground": "primaryBackground",
         "installFillBackground": "secondaryAccentColor",
         "installFocusedBackground": "primaryBackground",
-        "updateBorderColor": "#5da3f4",
+        "updateBorderColor": "#036a96",
         "updateForeground": "primaryForeground",
-        "updateBackground": "#5da3f4"
+        "updateBackground": "#036a96"
       },
       "Tab": {
         "selectedBackground": "hoverBackground",
@@ -189,14 +189,14 @@
       }
     },
     "ProgressBar": {
-      "failedColor": "#ff5554",
-      "failedEndColor": "#ff5554",
+      "failedColor": "#cb3a2a",
+      "failedEndColor": "#cb3a2a",
       "trackColor": "selectionBackground",
       "progressColor": "accentColor",
-      "indeterminateStartColor": "#93b8f9",
+      "indeterminateStartColor": "#7862d0",
       "indeterminateEndColor": "secondaryAccentColor",
-      "passedColor": "#50fa7b",
-      "passedEndColor": "#50fa7b"
+      "passedColor": "#14710a",
+      "passedEndColor": "#14710a"
     },
     "Popup": {
       "Header": {
@@ -217,7 +217,7 @@
         "background": "secondaryBackground"
       },
       "Tab": {
-        "selectedBackground": "#313341",
+        "selectedBackground": "#fffbeb",
         "selectedForeground": "primaryForeground"
       }
     },
@@ -239,7 +239,7 @@
       "contentAreaColor": "hoverBackground"
     },
     "Table": {
-      "gridColor": "#5d617a",
+      "gridColor": "#bcbab3",
       "hoverBackground": "selectionBackground",
       "lightSelectionBackground": "secondaryBackground"
     },
@@ -250,7 +250,7 @@
       "background": "secondaryBackground"
     },
     "ToggleButton": {
-      "onBackground": "#50fa7b",
+      "onBackground": "#14710a",
       "onForeground": "hoverBackground",
       "offBackground": "selectionBackground",
       "offForeground": "hoverBackground",
@@ -262,14 +262,14 @@
         "hoverBackground": "hoverBackground"
       },
       "Header": {
-        "background": "#484c60",
+        "background": "#efeddc",
         "inactiveBackground": "secondaryBackground"
       },
       "HeaderTab": {
         "underlineColor": "secondaryAccentColor",
         "underlineHeight": 2,
-        "underlinedTabBackground": "#292b38",
-        "underlinedTabInactiveBackground": "#313341"
+        "underlinedTabBackground": "#fffbeb",
+        "underlinedTabInactiveBackground": "#fffbeb"
       }
     },
     "Tree": {
@@ -279,8 +279,8 @@
       "hash": "hoverBackground"
     },
     "ValidationTooltip": {
-      "errorBackground": "#4c273c",
-      "warningBackground": "#4f4b41"
+      "errorBackground": "#e8d4dd",
+      "warningBackground": "#e8e6dc"
     },
     "VersionControl": {
       "FileHistory": {
@@ -289,11 +289,11 @@
         }
       },
       "GitLog": {
-        "headIconColor": "#f1fa8c",
-        "localBranchIconColor": "#50fa7b",
+        "headIconColor": "#846e15",
+        "localBranchIconColor": "#14710a",
         "remoteBranchIconColor": "secondaryAccentColor",
         "tagIconColor": "accentColor",
-        "otherIconColor": "#8be9fd"
+        "otherIconColor": "#036a96"
       },
       "Log": {
         "Commit": {
@@ -325,33 +325,33 @@
   },
   "icons": {
     "ColorPalette": {
-      "Actions.Blue": "#5da3f4",
-      "Actions.Green": "#2fc864",
-      "Actions.Grey": "#858994",
-      "Actions.GreyInline.Dark": "#2fc864",
-      "Actions.GreyInline": "#2fc864",
-      "Actions.Red": "#ff5554",
-      "Actions.Yellow": "#f1fa8c",
-      "Objects.Blue": "#5da3f4",
-      "Objects.Green": "#2fc864",
-      "Objects.GreenAndroid": "#2fc864",
-      "Objects.Grey": "#858994",
-      "Objects.Pink": "#ff79c6",
-      "Objects.Purple": "#bd93f9",
-      "Objects.Red": "#ff5554",
-      "Objects.RedStatus": "#ff5554",
-      "Objects.Yellow": "#f1fa8c",
-      "Objects.YellowDark": "#f1fa8c",
-      "Objects.BlackText": "#282a35",
-      "Checkbox.Foreground.Selected.Dark": "#f8f8f2",
-      "Checkbox.Border.Default.Dark": "#bd93f9",
-      "Checkbox.Border.Selected.Dark": "#bd93f9",
-      "Checkbox.Border.Disabled.Dark": "#6272a4",
-      "Checkbox.Background.Default.Dark": "#6272a4",
-      "Checkbox.Background.Disabled.Dark": "#414450",
-      "Checkbox.Focus.Wide.Dark": "#bd93f9",
-      "Checkbox.Focus.Thin.Selected.Dark": "#bd93f9",
-      "Checkbox.Focus.Thin.Default.Dark": "#bd93f9"
+      "Actions.Blue": "#036a96",
+      "Actions.Green": "#14710a",
+      "Actions.Grey": "#1f1f1f",
+      "Actions.GreyInline.Dark": "#1f1f1f",
+      "Actions.GreyInline": "#1f1f1f",
+      "Actions.Red": "#cb3a2a",
+      "Actions.Yellow": "#846e15",
+      "Objects.Blue": "#036a96",
+      "Objects.Green": "#14710a",
+      "Objects.GreenAndroid": "#14710a",
+      "Objects.Grey": "#1f1f1f",
+      "Objects.Pink": "#a3144d",
+      "Objects.Purple": "#644ac9",
+      "Objects.Red": "#cb3a2a",
+      "Objects.RedStatus": "#cb3a2a",
+      "Objects.Yellow": "#846e15",
+      "Objects.YellowDark": "#846e15",
+      "Objects.BlackText": "#1f1f1f",
+      "Checkbox.Foreground.Selected.Dark": "#1f1f1f",
+      "Checkbox.Border.Default.Dark": "#dedccf",
+      "Checkbox.Border.Selected.Dark": "#dedccf",
+      "Checkbox.Border.Disabled.Dark": "#6c664b",
+      "Checkbox.Background.Default.Dark": "#6c664b",
+      "Checkbox.Background.Disabled.Dark": "#ece9df",
+      "Checkbox.Focus.Wide.Dark": "#dedccf",
+      "Checkbox.Focus.Thin.Selected.Dark": "#dedccf",
+      "Checkbox.Focus.Thin.Default.Dark": "#dedccf"
     }
   }
 }

--- a/src/main/resources/themes/DraculaAlucard.xml
+++ b/src/main/resources/themes/DraculaAlucard.xml
@@ -1,0 +1,844 @@
+<scheme name="Dracula Alucard" version="142" parent_scheme="Default">
+  <colors>
+    <option name="ADDED_LINES_COLOR" value="14710a" />
+    <option name="ANNOTATIONS_COLOR" value="1f1f1f" />
+    <option name="CARET_COLOR" value="1f1f1f" />
+    <option name="CARET_ROW_COLOR" value="dedccf" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="fffbeb" />
+    <option name="DELETED_LINES_COLOR" value="cb3a2a" />
+    <option name="DOCUMENTATION_COLOR" value="dedccf" />
+    <option name="DOC_COMMENT_LINK" value="a3144d" />
+    <option name="FILESTATUS_ADDED" value="14710a" />
+    <option name="FILESTATUS_COPIED" value="14710a" />
+    <option name="FILESTATUS_DELETED" value="6c664b" />
+    <option name="FILESTATUS_IDEA_FILESTATUS_DELETED_FROM_FILE_SYSTEM" value="6c664b" />
+    <option name="FILESTATUS_IDEA_FILESTATUS_IGNORED" value="6c664b" />
+    <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_BOTH_CONFLICTS" value="cb3a2a" />
+    <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="cb3a2a" />
+    <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="cb3a2a" />
+    <option name="FILESTATUS_IDEA_SVN_FILESTATUS_EXTERNAL" value="a34d14" />
+    <option name="FILESTATUS_IDEA_SVN_FILESTATUS_OBSTRUCTED" value="846e15" />
+    <option name="FILESTATUS_IDEA_SVN_REPLACED" value="14710a" />
+    <option name="FILESTATUS_IGNORE.PROJECT_VIEW.IGNORED" value="56523c" />
+    <option name="FILESTATUS_MERGED" value="644ac9" />
+    <option name="FILESTATUS_MODIFIED" value="036a96" />
+    <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="036a96" />
+    <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="036a96" />
+    <option name="FILESTATUS_RENAMED" value="a3144d" />
+    <option name="FILESTATUS_UNKNOWN" value="cb3a2a" />
+    <option name="FILESTATUS_addedOutside" value="14710a" />
+    <option name="FILESTATUS_changelistConflict" value="cb3a2a" />
+    <option name="FILESTATUS_modifiedOutside" value="036a96" />
+    <option name="GUTTER_BACKGROUND" value="efeddc" />
+    <option name="INDENT_GUIDE" value="dedccf" />
+    <option name="INFORMATION_HINT" value="dedccf" />
+    <option name="LINE_NUMBERS_COLOR" value="6c664b" />
+    <option name="LINE_NUMBER_ON_CARET_ROW_COLOR" value="a3144d" />
+    <option name="LOOKUP_COLOR" value="dedccf" />
+    <option name="MODIFIED_LINES_COLOR" value="036a96" />
+    <option name="RIGHT_MARGIN_COLOR" value="6c664b" />
+    <option name="SELECTED_INDENT_GUIDE" value="6c664b" />
+    <option name="SELECTED_TEARLINE_COLOR" value="6c664b" />
+    <option name="SELECTION_BACKGROUND" value="d8d6c9" />
+    <option name="SELECTION_FOREGROUND" value="" />
+    <option name="SEPARATOR_ABOVE_COLOR" value="bcbab3" />
+    <option name="SEPARATOR_BELOW_COLOR" value="bcbab3" />
+    <option name="ScrollBar.Mac.hoverThumbColor" value="dedccf" />
+    <option name="ScrollBar.Mac.thumbColor" value="dedccf83" />
+    <option name="TEARLINE_COLOR" value="bcbab3" />
+    <option name="VCS_ANNOTATIONS_COLOR_1" value="644ac9" />
+    <option name="VCS_ANNOTATIONS_COLOR_2" value="a3144d" />
+    <option name="VCS_ANNOTATIONS_COLOR_3" value="a34d14" />
+    <option name="VCS_ANNOTATIONS_COLOR_4" value="14710a" />
+    <option name="VCS_ANNOTATIONS_COLOR_5" value="036a96" />
+    <option name="VISUAL_INDENT_GUIDE" value="bcbab3" />
+    <option name="WHITESPACES_MODIFIED_LINES_COLOR" value="a34d14" />
+  </colors>
+  <attributes>
+    <option name="ANNOTATION_ATTRIBUTE_NAME_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="036a96" />
+      </value>
+    </option>
+    <option name="ANNOTATION_NAME_ATTRIBUTES" baseAttributes="DEFAULT_METADATA" />
+    <option name="ANONYMOUS_CLASS_NAME_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="036a96" />
+      </value>
+    </option>
+    <option name="Abstract class name">
+      <value>
+        <option name="FOREGROUND" value="036a96" />
+      </value>
+    </option>
+    <option name="Annotation">
+      <value>
+        <option name="FOREGROUND" value="14710a" />
+      </value>
+    </option>
+    <option name="Anotation attribute name">
+      <value>
+        <option name="FOREGROUND" value="a34d14" />
+      </value>
+    </option>
+    <option name="BAD_CHARACTER">
+      <value>
+        <option name="EFFECT_COLOR" value="cb3a2a" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="BASH.EXTERNAL_COMMAND">
+      <value>
+        <option name="FOREGROUND" value="036a96" />
+      </value>
+    </option>
+    <option name="BASH.INTERNAL_COMMAND">
+      <value>
+        <option name="FOREGROUND" value="036a96" />
+      </value>
+    </option>
+    <option name="BREADCRUMBS_CURRENT">
+      <value>
+        <option name="FOREGROUND" value="644ac9" />
+      </value>
+    </option>
+    <option name="BREADCRUMBS_DEFAULT">
+      <value>
+        <option name="FOREGROUND" value="6c664b" />
+      </value>
+    </option>
+    <option name="BREADCRUMBS_HOVERED">
+      <value>
+        <option name="FOREGROUND" value="1f1f1f" />
+        <option name="BACKGROUND" value="dedccf" />
+      </value>
+    </option>
+    <option name="BREADCRUMBS_INACTIVE">
+      <value>
+        <option name="FOREGROUND" value="6c664b" />
+      </value>
+    </option>
+    <option name="BREAKPOINT_ATTRIBUTES">
+      <value>
+        <option name="BACKGROUND" value="cb3a2a" />
+        <option name="ERROR_STRIPE_COLOR" value="cb3a2a" />
+      </value>
+    </option>
+    <option name="CLASS_NAME_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="644ac9" />
+      </value>
+    </option>
+    <option name="CONSOLE_BLACK_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="fffbeb" />
+      </value>
+    </option>
+    <option name="CONSOLE_BLUE_BRIGHT_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="7862d0" />
+      </value>
+    </option>
+    <option name="CONSOLE_BLUE_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="644ac9" />
+      </value>
+    </option>
+    <option name="CONSOLE_CYAN_BRIGHT_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="047fb4" />
+      </value>
+    </option>
+    <option name="CONSOLE_CYAN_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="036a96" />
+      </value>
+    </option>
+    <option name="CONSOLE_DARKGRAY_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="6c664b" />
+      </value>
+    </option>
+    <option name="CONSOLE_ERROR_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="cb3a2a" />
+      </value>
+    </option>
+    <option name="CONSOLE_GREEN_BRIGHT_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="198d0c" />
+      </value>
+    </option>
+    <option name="CONSOLE_GREEN_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="14710a" />
+      </value>
+    </option>
+    <option name="CONSOLE_MAGENTA_BRIGHT_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="bf185a" />
+      </value>
+    </option>
+    <option name="CONSOLE_MAGENTA_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="a3144d" />
+      </value>
+    </option>
+    <option name="CONSOLE_NORMAL_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="1f1f1f" />
+      </value>
+    </option>
+    <option name="CONSOLE_RED_BRIGHT_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="d74c3d" />
+      </value>
+    </option>
+    <option name="CONSOLE_RED_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="cb3a2a" />
+      </value>
+    </option>
+    <option name="CONSOLE_SYSTEM_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="1f1f1f" />
+      </value>
+    </option>
+    <option name="CONSOLE_USER_INPUT">
+      <value>
+        <option name="FOREGROUND" value="14710a" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="CONSOLE_WHITE_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="2c2b31" />
+      </value>
+    </option>
+    <option name="CONSOLE_YELLOW_BRIGHT_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="9e841a" />
+      </value>
+    </option>
+    <option name="CONSOLE_YELLOW_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="846e15" />
+      </value>
+    </option>
+    <option name="CONSTRUCTOR_CALL_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="644ac9" />
+      </value>
+    </option>
+    <option name="CONSTRUCTOR_DECLARATION_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="644ac9" />
+      </value>
+    </option>
+    <option name="CTRL_CLICKABLE">
+      <value>
+        <option name="FOREGROUND" value="036a96" />
+        <option name="EFFECT_COLOR" value="036a96" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="CUSTOM_KEYWORD1_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="a3144d" />
+      </value>
+    </option>
+    <option name="CUSTOM_KEYWORD2_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="a3144d" />
+      </value>
+    </option>
+    <option name="CUSTOM_KEYWORD3_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="a3144d" />
+      </value>
+    </option>
+    <option name="CUSTOM_KEYWORD4_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="a3144d" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="CUSTOM_STRING_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="14710a" />
+      </value>
+    </option>
+    <option name="CUSTOM_VALID_STRING_ESCAPE_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="a34d14" />
+      </value>
+    </option>
+    <option name="Class">
+      <value>
+        <option name="FOREGROUND" value="644ac9" />
+      </value>
+    </option>
+    <option name="DEFAULT_ATTRIBUTE">
+      <value>
+        <option name="FOREGROUND" value="a34d14" />
+      </value>
+    </option>
+    <option name="DEFAULT_BLOCK_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="6c664b" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="DEFAULT_BRACES">
+      <value>
+        <option name="FOREGROUND" value="1f1f1f" />
+      </value>
+    </option>
+    <option name="DEFAULT_BRACKETS">
+      <value>
+        <option name="FOREGROUND" value="1f1f1f" />
+      </value>
+    </option>
+    <option name="DEFAULT_CLASS_NAME">
+      <value>
+        <option name="FOREGROUND" value="644ac9" />
+      </value>
+    </option>
+    <option name="DEFAULT_CLASS_REFERENCE">
+      <value>
+        <option name="FOREGROUND" value="644ac9" />
+      </value>
+    </option>
+    <option name="DEFAULT_COMMA">
+      <value>
+        <option name="FOREGROUND" value="1f1f1f" />
+      </value>
+    </option>
+    <option name="DEFAULT_CONSTANT">
+      <value>
+        <option name="FOREGROUND" value="a34d14" />
+      </value>
+    </option>
+    <option name="DEFAULT_DOC_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="6c664b" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="DEFAULT_DOC_COMMENT_TAG">
+      <value>
+        <option name="FOREGROUND" value="a3144d" />
+        <option name="FONT_TYPE" value="3" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="DEFAULT_DOC_COMMENT_TAG_VALUE">
+      <value>
+        <option name="FOREGROUND" value="a34d14" />
+      </value>
+    </option>
+    <option name="DEFAULT_DOC_MARKUP">
+      <value>
+        <option name="FOREGROUND" value="a34d14" />
+      </value>
+    </option>
+    <option name="DEFAULT_DOT">
+      <value>
+        <option name="FOREGROUND" value="1f1f1f" />
+      </value>
+    </option>
+    <option name="DEFAULT_ENTITY">
+      <value>
+        <option name="FOREGROUND" value="a34d14" />
+      </value>
+    </option>
+    <option name="DEFAULT_FUNCTION_CALL">
+      <value>
+        <option name="FOREGROUND" value="846e15" />
+      </value>
+    </option>
+    <option name="DEFAULT_FUNCTION_DECLARATION">
+      <value>
+        <option name="FOREGROUND" value="846e15" />
+      </value>
+    </option>
+    <option name="DEFAULT_GLOBAL_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="644ac9" />
+      </value>
+    </option>
+    <option name="DEFAULT_IDENTIFIER">
+      <value>
+        <option name="FOREGROUND" value="1f1f1f" />
+      </value>
+    </option>
+    <option name="DEFAULT_INSTANCE_FIELD">
+      <value>
+        <option name="FOREGROUND" value="644ac9" />
+      </value>
+    </option>
+    <option name="DEFAULT_INSTANCE_METHOD">
+      <value>
+        <option name="FOREGROUND" value="846e15" />
+      </value>
+    </option>
+    <option name="DEFAULT_INTERFACE_NAME">
+      <value>
+        <option name="FOREGROUND" value="644ac9" />
+      </value>
+    </option>
+    <option name="DEFAULT_INVALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="cb3a2a" />
+        <option name="EFFECT_COLOR" value="cb3a2a" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="DEFAULT_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="a3144d" />
+      </value>
+    </option>
+    <option name="DEFAULT_LABEL">
+      <value>
+        <option name="FOREGROUND" value="a34d14" />
+      </value>
+    </option>
+    <option name="DEFAULT_LINE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="6c664b" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="DEFAULT_LOCAL_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="644ac9" />
+      </value>
+    </option>
+    <option name="DEFAULT_METADATA">
+      <value>
+        <option name="FOREGROUND" value="14710a" />
+      </value>
+    </option>
+    <option name="DEFAULT_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="a34d14" />
+      </value>
+    </option>
+    <option name="DEFAULT_OPERATION_SIGN">
+      <value>
+        <option name="FOREGROUND" value="1f1f1f" />
+      </value>
+    </option>
+    <option name="DEFAULT_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="644ac9" />
+      </value>
+    </option>
+    <option name="DEFAULT_PARENTHS">
+      <value>
+        <option name="FOREGROUND" value="1f1f1f" />
+      </value>
+    </option>
+    <option name="DEFAULT_PREDEFINED_SYMBOL">
+      <value>
+        <option name="FOREGROUND" value="036a96" />
+      </value>
+    </option>
+    <option name="DEFAULT_REASSIGNED_LOCAL_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="644ac9" />
+        <option name="EFFECT_COLOR" value="644ac9" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="DEFAULT_REASSIGNED_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="644ac9" />
+        <option name="EFFECT_COLOR" value="644ac9" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="DEFAULT_SEMICOLON">
+      <value>
+        <option name="FOREGROUND" value="1f1f1f" />
+      </value>
+    </option>
+    <option name="DEFAULT_STATIC_FIELD">
+      <value>
+        <option name="FOREGROUND" value="644ac9" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="DEFAULT_STATIC_METHOD">
+      <value>
+        <option name="FOREGROUND" value="846e15" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="DEFAULT_STRING">
+      <value>
+        <option name="FOREGROUND" value="14710a" />
+      </value>
+    </option>
+    <option name="DEFAULT_TAG">
+      <value>
+        <option name="FOREGROUND" value="a3144d" />
+      </value>
+    </option>
+    <option name="DEFAULT_TEMPLATE_LANGUAGE_COLOR">
+      <value>
+        <option name="FOREGROUND" value="1f1f1f" />
+      </value>
+    </option>
+    <option name="DEFAULT_VALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="a34d14" />
+      </value>
+    </option>
+    <option name="DELETED_TEXT_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="fffbeb" />
+        <option name="BACKGROUND" value="cb3a2a" />
+        <option name="EFFECT_COLOR" value="fffbeb" />
+        <option name="EFFECT_TYPE" value="3" />
+      </value>
+    </option>
+    <option name="DEPRECATED_ATTRIBUTES">
+      <value>
+        <option name="EFFECT_COLOR" value="cb3a2a" />
+        <option name="EFFECT_TYPE" value="3" />
+      </value>
+    </option>
+    <option name="DIFF_CONFLICT">
+      <value>
+        <option name="BACKGROUND" value="f0c0bd" />
+        <option name="ERROR_STRIPE_COLOR" value="cb3a2a" />
+      </value>
+    </option>
+    <option name="DIFF_DELETED">
+      <value>
+        <option name="BACKGROUND" value="f0c0bd" />
+        <option name="ERROR_STRIPE_COLOR" value="cb3a2a" />
+      </value>
+    </option>
+    <option name="DIFF_INSERTED">
+      <value>
+        <option name="BACKGROUND" value="c0dcc2" />
+        <option name="ERROR_STRIPE_COLOR" value="14710a" />
+      </value>
+    </option>
+    <option name="DIFF_MODIFIED">
+      <value>
+        <option name="BACKGROUND" value="c0d5e0" />
+        <option name="ERROR_STRIPE_COLOR" value="036a96" />
+      </value>
+    </option>
+    <option name="DUPLICATE_FROM_SERVER">
+      <value>
+        <option name="FOREGROUND" value="1f1f1f" />
+        <option name="BACKGROUND" value="dedccf" />
+      </value>
+    </option>
+    <option name="ERRORS_ATTRIBUTES">
+      <value>
+        <option name="EFFECT_COLOR" value="cb3a2a" />
+        <option name="ERROR_STRIPE_COLOR" value="cb3a2a" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="EVALUATED_EXPRESSION_ATTRIBUTES">
+      <value>
+        <option name="BACKGROUND" value="dedccf" />
+      </value>
+    </option>
+    <option name="EVALUATED_EXPRESSION_EXECUTION_LINE_ATTRIBUTES">
+      <value>
+        <option name="BACKGROUND" value="dedccf" />
+      </value>
+    </option>
+    <option name="EXECUTIONPOINT_ATTRIBUTES">
+      <value>
+        <option name="BACKGROUND" value="dedccf" />
+        <option name="ERROR_STRIPE_COLOR" value="dedccf" />
+      </value>
+    </option>
+    <option name="FOLDED_TEXT_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="6c664b" />
+        <option name="BACKGROUND" value="dedccf" />
+        <option name="EFFECT_COLOR" value="6c664b" />
+      </value>
+    </option>
+    <option name="FOLLOWED_HYPERLINK_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="036a96" />
+        <option name="EFFECT_COLOR" value="036a96" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="GENERIC_SERVER_ERROR_OR_WARNING">
+      <value>
+        <option name="EFFECT_COLOR" value="cb3a2a" />
+        <option name="ERROR_STRIPE_COLOR" value="cb3a2a" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="HYPERLINK_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="036a96" />
+        <option name="EFFECT_COLOR" value="036a96" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="IDENTIFIER_UNDER_CARET_ATTRIBUTES">
+      <value>
+        <option name="BACKGROUND" value="dedccf" />
+        <option name="ERROR_STRIPE_COLOR" value="dedccf" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="IMPLICIT_ANONYMOUS_CLASS_PARAMETER_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="644ac9" />
+      </value>
+    </option>
+    <option name="INACTIVE_HYPERLINK_ATTRIBUTES">
+      <value>
+        <option name="EFFECT_COLOR" value="6c664b" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="INFO_ATTRIBUTES">
+      <value>
+        <option name="EFFECT_COLOR" value="846e15" />
+        <option name="ERROR_STRIPE_COLOR" value="846e15" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="INJECTED_LANGUAGE_FRAGMENT">
+      <value>
+        <option name="FOREGROUND" value="1f1f1f" />
+      </value>
+    </option>
+    <option name="INLINE_PARAMETER_HINT">
+      <value>
+        <option name="FOREGROUND" value="1f1f1f" />
+        <option name="BACKGROUND" value="dedccf" />
+      </value>
+    </option>
+    <option name="INLINE_PARAMETER_HINT_CURRENT">
+      <value>
+        <option name="FOREGROUND" value="1f1f1f" />
+        <option name="BACKGROUND" value="dedccf" />
+      </value>
+    </option>
+    <option name="INLINE_PARAMETER_HINT_HIGHLIGHTED">
+      <value>
+        <option name="FOREGROUND" value="1f1f1f" />
+        <option name="BACKGROUND" value="dedccf" />
+      </value>
+    </option>
+    <option name="INSTANCE_FIELD_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="644ac9" />
+      </value>
+    </option>
+    <option name="INTERFACE_NAME_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="644ac9" />
+      </value>
+    </option>
+    <option name="KOTLIN_BACKING_FIELD_VARIABLE">
+      <value />
+    </option>
+    <option name="KOTLIN_DYNAMIC_FUNCTION_CALL">
+      <value>
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="KOTLIN_DYNAMIC_PROPERTY_CALL">
+      <value>
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="KOTLIN_LABEL">
+      <value>
+        <option name="FOREGROUND" value="a34d14" />
+      </value>
+    </option>
+    <option name="KOTLIN_NAMED_ARGUMENT">
+      <value>
+        <option name="FOREGROUND" value="a34d14" />
+      </value>
+    </option>
+    <option name="KOTLIN_SMART_CAST_RECEIVER">
+      <value>
+        <option name="BACKGROUND" value="dedccf" />
+      </value>
+    </option>
+    <option name="KOTLIN_SMART_CAST_VALUE">
+      <value>
+        <option name="BACKGROUND" value="dedccf" />
+      </value>
+    </option>
+    <option name="KOTLIN_SMART_CONSTANT">
+      <value>
+        <option name="BACKGROUND" value="dedccf" />
+      </value>
+    </option>
+    <option name="KOTLIN_TYPE_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="a34d14" />
+      </value>
+    </option>
+    <option name="LOG_DEBUG_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="14710a" />
+      </value>
+    </option>
+    <option name="LOG_ERROR_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="cb3a2a" />
+      </value>
+    </option>
+    <option name="LOG_EXPIRED_ENTRY">
+      <value>
+        <option name="FOREGROUND" value="6c664b" />
+      </value>
+    </option>
+    <option name="LOG_INFO_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="036a96" />
+      </value>
+    </option>
+    <option name="LOG_VERBOSE_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="036a96" />
+      </value>
+    </option>
+    <option name="LOG_WARNING_OUTPUT">
+      <value>
+        <option name="FOREGROUND" value="a34d14" />
+      </value>
+    </option>
+    <option name="MARKED_FOR_REMOVAL_ATTRIBUTES">
+      <value>
+        <option name="EFFECT_COLOR" value="cb3a2a" />
+        <option name="EFFECT_TYPE" value="3" />
+      </value>
+    </option>
+    <option name="MATCHED_BRACE_ATTRIBUTES">
+      <value>
+        <option name="BACKGROUND" value="dedccf" />
+      </value>
+    </option>
+    <option name="METHOD_CALL_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="846e15" />
+      </value>
+    </option>
+    <option name="METHOD_DECLARATION_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="846e15" />
+      </value>
+    </option>
+    <option name="NOT_USED_ELEMENT_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="6c664b" />
+      </value>
+    </option>
+    <option name="PARAMETER_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="644ac9" />
+      </value>
+    </option>
+    <option name="SEARCH_RESULT_ATTRIBUTES">
+      <value>
+        <option name="BACKGROUND" value="dedccf" />
+        <option name="ERROR_STRIPE_COLOR" value="dedccf" />
+      </value>
+    </option>
+    <option name="STATIC_FIELD_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="644ac9" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="STATIC_FINAL_FIELD_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="a34d14" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="STATIC_METHOD_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="846e15" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="TEMPLATE_VARIABLE_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="644ac9" />
+      </value>
+    </option>
+    <option name="TEXT">
+      <value>
+        <option name="FOREGROUND" value="1f1f1f" />
+        <option name="BACKGROUND" value="fffbeb" />
+      </value>
+    </option>
+    <option name="TEXT_SEARCH_RESULT_ATTRIBUTES">
+      <value>
+        <option name="BACKGROUND" value="dedccf" />
+        <option name="ERROR_STRIPE_COLOR" value="dedccf" />
+      </value>
+    </option>
+    <option name="TODO_DEFAULT_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="a34d14" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="a34d14" />
+      </value>
+    </option>
+    <option name="TYPO">
+      <value>
+        <option name="EFFECT_COLOR" value="14710a" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="UNMATCHED_BRACE_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="cb3a2a" />
+      </value>
+    </option>
+    <option name="WARNING_ATTRIBUTES">
+      <value>
+        <option name="EFFECT_COLOR" value="a34d14" />
+        <option name="ERROR_STRIPE_COLOR" value="a34d14" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
+      <value>
+        <option name="BACKGROUND" value="dedccf" />
+        <option name="ERROR_STRIPE_COLOR" value="dedccf" />
+      </value>
+    </option>
+    <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">
+      <value>
+        <option name="BACKGROUND" value="dedccf" />
+        <option name="ERROR_STRIPE_COLOR" value="dedccf" />
+      </value>
+    </option>
+    <option name="WRONG_REFERENCES_ATTRIBUTES">
+      <value>
+        <option name="FOREGROUND" value="cb3a2a" />
+      </value>
+    </option>
+  </attributes>
+</scheme>

--- a/src/main/resources/themes/DraculaColorful.theme.json
+++ b/src/main/resources/themes/DraculaColorful.theme.json
@@ -5,7 +5,7 @@
   "editorScheme": "/themes/DraculaColorful.xml",
   "colors": {
     "accentColor": "#ff79c6",
-    "secondaryAccentColor": "#bd93f9",
+    "secondaryAccentColor": "#3a3d4c",
     "primaryForeground": "#f8f8f2",
     "primaryBackground": "#414450",
     "secondaryBackground": "#3a3d4c",

--- a/src/main/resources/themes/DraculaColorful.xml
+++ b/src/main/resources/themes/DraculaColorful.xml
@@ -3,7 +3,7 @@
     <option name="ADDED_LINES_COLOR" value="48b764" />
     <option name="ANNOTATIONS_COLOR" value="f8f8f2" />
     <option name="CARET_COLOR" value="cccccc" />
-    <option name="CARET_ROW_COLOR" value="44475a" />
+    <option name="CARET_ROW_COLOR" value="3a3d4c" />
     <option name="CONSOLE_BACKGROUND_KEY" value="282a36" />
     <option name="DELETED_LINES_COLOR" value="cd4644" />
     <option name="DOCUMENTATION_COLOR" value="3a3d4c" />
@@ -19,7 +19,7 @@
     <option name="FILESTATUS_IDEA_SVN_FILESTATUS_EXTERNAL" value="ffb86c" />
     <option name="FILESTATUS_IDEA_SVN_FILESTATUS_OBSTRUCTED" value="f1fa8c" />
     <option name="FILESTATUS_IDEA_SVN_REPLACED" value="50fa7b" />
-    <option name="FILESTATUS_IGNORE.PROJECT_VIEW.IGNORED" value="808080" />
+    <option name="FILESTATUS_IGNORE.PROJECT_VIEW.IGNORED" value="9a9a9a" />
     <option name="FILESTATUS_MERGED" value="bd93f9" />
     <option name="FILESTATUS_MODIFIED" value="8be9fd" />
     <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="8be9fd" />
@@ -42,8 +42,8 @@
     <option name="SELECTION_BACKGROUND" value="666b87" />
     <option name="SEPARATOR_ABOVE_COLOR" value="6b7090" />
     <option name="SEPARATOR_BELOW_COLOR" value="6b7090" />
-    <option name="ScrollBar.Mac.hoverThumbColor" value="bd93f9" />
-    <option name="ScrollBar.Mac.thumbColor" value="bd93f983" />
+    <option name="ScrollBar.Mac.hoverThumbColor" value="3a3d4c" />
+    <option name="ScrollBar.Mac.thumbColor" value="3a3d4c83" />
     <option name="TEARLINE_COLOR" value="6b7090" />
     <option name="VCS_ANNOTATIONS_COLOR_1" value="8d64b0" />
     <option name="VCS_ANNOTATIONS_COLOR_2" value="c6538d" />


### PR DESCRIPTION
Hey there!

I'm very impressed by the new light theme specification, and I tried to create a simple prototype of the theme. Maybe it'll be useful, and of course, if you think that the implementation has potential, I can continue enhancing the prototype until it'll be ready to become a part of the official theme.

<img width="1840" height="1191" alt="image" src="https://github.com/user-attachments/assets/0f98e89b-aa01-4488-ada8-9507ce90eebf" />

<img width="1840" height="1191" alt="image" src="https://github.com/user-attachments/assets/ce785966-3536-4083-81f4-70d2c7a49d51" />
