### PR TITLE
Fix invisible selected tool window icon in Alucard themes

### DIFF
--- a/src/main/resources/themes/DraculaAlucard.theme.json
+++ b/src/main/resources/themes/DraculaAlucard.theme.json
@@ -265,6 +265,7 @@
     "ToolWindow": {
       "background": "secondaryBackground",
       "Button": {
+        "selectedForeground": "primaryForeground",
         "selectedBackground": "hoverBackground",
         "hoverBackground": "hoverBackground"
       },

--- a/src/main/resources/themes/IslandsDraculaAlucard.theme.json
+++ b/src/main/resources/themes/IslandsDraculaAlucard.theme.json
@@ -274,6 +274,7 @@
     "ToolWindow": {
       "background": "secondaryBackground",
       "Button": {
+        "selectedForeground": "primaryForeground",
         "selectedBackground": "hoverBackground",
         "hoverBackground": "hoverBackground"
       },


### PR DESCRIPTION
The Alucard (light) themes never define ToolWindow.Button.selectedForeground, so the selected stripe button icon stays light against the light selectedBackground (#fffbeb) and becomes nearly invisible.

Set selectedForeground to primaryForeground (#1f1f1f) for both DraculaAlucard and IslandsDraculaAlucard.

## Previous
<img width="196" height="276" alt="CleanShot 2026-05-21 at 10 10 29@2x" src="https://github.com/user-attachments/assets/de140bf9-cea0-4365-b0aa-e46fb636046d" />

## Fixed

<img width="152" height="164" alt="CleanShot 2026-05-21 at 10 33 21@2x" src="https://github.com/user-attachments/assets/216eb722-ecba-4506-ad83-317348e870fe" />
