### PR TITLE
Add reworked terminal colors

### DIFF
--- a/src/main/resources/themes/Dracula.xml
+++ b/src/main/resources/themes/Dracula.xml
@@ -2,6 +2,8 @@
   <colors>
     <option name="ADDED_LINES_COLOR" value="48b764" />
     <option name="ANNOTATIONS_COLOR" value="f8f8f2" />
+    <option name="BLOCK_TERMINAL_DEFAULT_BACKGROUND" value="282a36" />
+    <option name="BLOCK_TERMINAL_DEFAULT_FOREGROUND" value="f8f8f2" />
     <option name="CARET_COLOR" value="cccccc" />
     <option name="CARET_ROW_COLOR" value="1e1f29" />
     <option name="CONSOLE_BACKGROUND_KEY" value="282a36" />
@@ -130,16 +132,6 @@
       <value>
         <option name="FOREGROUND" value="a4ffff" />
         <option name="BACKGROUND" value="a4ffff" />
-      </value>
-    </option>
-    <option name="BLOCK_TERMINAL_DEFAULT_BACKGROUND">
-      <value>
-        <option name="BACKGROUND" value="282a36" />
-      </value>
-    </option>
-    <option name="BLOCK_TERMINAL_DEFAULT_FOREGROUND">
-      <value>
-        <option name="FOREGROUND" value="f8f8f2" />
       </value>
     </option>
     <option name="BLOCK_TERMINAL_GREEN">

--- a/src/main/resources/themes/Dracula.xml
+++ b/src/main/resources/themes/Dracula.xml
@@ -96,6 +96,112 @@
         <option name="FOREGROUND" value="8be9fd" />
       </value>
     </option>
+    <option name="BLOCK_TERMINAL_BLACK">
+      <value>
+        <option name="FOREGROUND" value="21222c" />
+        <option name="BACKGROUND" value="21222c" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_BLACK_BRIGHT">
+      <value>
+        <option name="FOREGROUND" value="6272a4" />
+        <option name="BACKGROUND" value="6272a4" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_BLUE">
+      <value>
+        <option name="FOREGROUND" value="bd93f9" />
+        <option name="BACKGROUND" value="bd93f9" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_BLUE_BRIGHT">
+      <value>
+        <option name="FOREGROUND" value="d6acff" />
+        <option name="BACKGROUND" value="d6acff" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_CYAN">
+      <value>
+        <option name="FOREGROUND" value="8be9fd" />
+        <option name="BACKGROUND" value="8be9fd" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_CYAN_BRIGHT">
+      <value>
+        <option name="FOREGROUND" value="a4ffff" />
+        <option name="BACKGROUND" value="a4ffff" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_DEFAULT_BACKGROUND">
+      <value>
+        <option name="BACKGROUND" value="282a36" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_DEFAULT_FOREGROUND">
+      <value>
+        <option name="FOREGROUND" value="f8f8f2" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_GREEN">
+      <value>
+        <option name="FOREGROUND" value="50fa7b" />
+        <option name="BACKGROUND" value="50fa7b" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_GREEN_BRIGHT">
+      <value>
+        <option name="FOREGROUND" value="69ff94" />
+        <option name="BACKGROUND" value="69ff94" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_MAGENTA">
+      <value>
+        <option name="FOREGROUND" value="ff79c6" />
+        <option name="BACKGROUND" value="ff79c6" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_MAGENTA_BRIGHT">
+      <value>
+        <option name="FOREGROUND" value="ff92df" />
+        <option name="BACKGROUND" value="ff92df" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_RED">
+      <value>
+        <option name="FOREGROUND" value="ff5555" />
+        <option name="BACKGROUND" value="ff5555" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_RED_BRIGHT">
+      <value>
+        <option name="FOREGROUND" value="ff6e6e" />
+        <option name="BACKGROUND" value="ff6e6e" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_WHITE">
+      <value>
+        <option name="FOREGROUND" value="f8f8f2" />
+        <option name="BACKGROUND" value="f8f8f2" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_WHITE_BRIGHT">
+      <value>
+        <option name="FOREGROUND" value="ffffff" />
+        <option name="BACKGROUND" value="ffffff" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_YELLOW">
+      <value>
+        <option name="FOREGROUND" value="f1fa8c" />
+        <option name="BACKGROUND" value="f1fa8c" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_YELLOW_BRIGHT">
+      <value>
+        <option name="FOREGROUND" value="ffffa5" />
+        <option name="BACKGROUND" value="ffffa5" />
+      </value>
+    </option>
     <option name="BREADCRUMBS_CURRENT">
       <value>
         <option name="FOREGROUND" value="bd93f9" />

--- a/src/main/resources/themes/DraculaAlucard.xml
+++ b/src/main/resources/themes/DraculaAlucard.xml
@@ -2,6 +2,8 @@
   <colors>
     <option name="ADDED_LINES_COLOR" value="14710a" />
     <option name="ANNOTATIONS_COLOR" value="1f1f1f" />
+    <option name="BLOCK_TERMINAL_DEFAULT_BACKGROUND" value="fffbeb" />
+    <option name="BLOCK_TERMINAL_DEFAULT_FOREGROUND" value="1f1f1f" />
     <option name="CARET_COLOR" value="1f1f1f" />
     <option name="CARET_ROW_COLOR" value="dedccf" />
     <option name="CONSOLE_BACKGROUND_KEY" value="fffbeb" />
@@ -95,6 +97,102 @@
     <option name="BASH.INTERNAL_COMMAND">
       <value>
         <option name="FOREGROUND" value="036a96" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_BLACK">
+      <value>
+        <option name="FOREGROUND" value="fffbeb" />
+        <option name="BACKGROUND" value="fffbeb" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_BLACK_BRIGHT">
+      <value>
+        <option name="FOREGROUND" value="6c664b" />
+        <option name="BACKGROUND" value="6c664b" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_BLUE">
+      <value>
+        <option name="FOREGROUND" value="644ac9" />
+        <option name="BACKGROUND" value="644ac9" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_BLUE_BRIGHT">
+      <value>
+        <option name="FOREGROUND" value="7862d0" />
+        <option name="BACKGROUND" value="7862d0" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_CYAN">
+      <value>
+        <option name="FOREGROUND" value="036a96" />
+        <option name="BACKGROUND" value="036a96" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_CYAN_BRIGHT">
+      <value>
+        <option name="FOREGROUND" value="047fb4" />
+        <option name="BACKGROUND" value="047fb4" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_GREEN">
+      <value>
+        <option name="FOREGROUND" value="14710a" />
+        <option name="BACKGROUND" value="14710a" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_GREEN_BRIGHT">
+      <value>
+        <option name="FOREGROUND" value="198d0c" />
+        <option name="BACKGROUND" value="198d0c" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_MAGENTA">
+      <value>
+        <option name="FOREGROUND" value="a3144d" />
+        <option name="BACKGROUND" value="a3144d" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_MAGENTA_BRIGHT">
+      <value>
+        <option name="FOREGROUND" value="bf185a" />
+        <option name="BACKGROUND" value="bf185a" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_RED">
+      <value>
+        <option name="FOREGROUND" value="cb3a2a" />
+        <option name="BACKGROUND" value="cb3a2a" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_RED_BRIGHT">
+      <value>
+        <option name="FOREGROUND" value="d74c3d" />
+        <option name="BACKGROUND" value="d74c3d" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_WHITE">
+      <value>
+        <option name="FOREGROUND" value="6c664b" />
+        <option name="BACKGROUND" value="6c664b" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_WHITE_BRIGHT">
+      <value>
+        <option name="FOREGROUND" value="1f1f1f" />
+        <option name="BACKGROUND" value="1f1f1f" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_YELLOW">
+      <value>
+        <option name="FOREGROUND" value="846e15" />
+        <option name="BACKGROUND" value="846e15" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_YELLOW_BRIGHT">
+      <value>
+        <option name="FOREGROUND" value="9e841a" />
+        <option name="BACKGROUND" value="9e841a" />
       </value>
     </option>
     <option name="BREADCRUMBS_CURRENT">

--- a/src/main/resources/themes/DraculaColorful.xml
+++ b/src/main/resources/themes/DraculaColorful.xml
@@ -2,6 +2,8 @@
   <colors>
     <option name="ADDED_LINES_COLOR" value="48b764" />
     <option name="ANNOTATIONS_COLOR" value="f8f8f2" />
+    <option name="BLOCK_TERMINAL_DEFAULT_BACKGROUND" value="282a36" />
+    <option name="BLOCK_TERMINAL_DEFAULT_FOREGROUND" value="f8f8f2" />
     <option name="CARET_COLOR" value="cccccc" />
     <option name="CARET_ROW_COLOR" value="1e1f29" />
     <option name="CONSOLE_BACKGROUND_KEY" value="282a36" />
@@ -130,16 +132,6 @@
       <value>
         <option name="FOREGROUND" value="a4ffff" />
         <option name="BACKGROUND" value="a4ffff" />
-      </value>
-    </option>
-    <option name="BLOCK_TERMINAL_DEFAULT_BACKGROUND">
-      <value>
-        <option name="BACKGROUND" value="282a36" />
-      </value>
-    </option>
-    <option name="BLOCK_TERMINAL_DEFAULT_FOREGROUND">
-      <value>
-        <option name="FOREGROUND" value="f8f8f2" />
       </value>
     </option>
     <option name="BLOCK_TERMINAL_GREEN">

--- a/src/main/resources/themes/DraculaColorful.xml
+++ b/src/main/resources/themes/DraculaColorful.xml
@@ -96,6 +96,112 @@
         <option name="FOREGROUND" value="8be9fd" />
       </value>
     </option>
+    <option name="BLOCK_TERMINAL_BLACK">
+      <value>
+        <option name="FOREGROUND" value="21222c" />
+        <option name="BACKGROUND" value="21222c" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_BLACK_BRIGHT">
+      <value>
+        <option name="FOREGROUND" value="6272a4" />
+        <option name="BACKGROUND" value="6272a4" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_BLUE">
+      <value>
+        <option name="FOREGROUND" value="bd93f9" />
+        <option name="BACKGROUND" value="bd93f9" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_BLUE_BRIGHT">
+      <value>
+        <option name="FOREGROUND" value="d6acff" />
+        <option name="BACKGROUND" value="d6acff" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_CYAN">
+      <value>
+        <option name="FOREGROUND" value="8be9fd" />
+        <option name="BACKGROUND" value="8be9fd" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_CYAN_BRIGHT">
+      <value>
+        <option name="FOREGROUND" value="a4ffff" />
+        <option name="BACKGROUND" value="a4ffff" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_DEFAULT_BACKGROUND">
+      <value>
+        <option name="BACKGROUND" value="282a36" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_DEFAULT_FOREGROUND">
+      <value>
+        <option name="FOREGROUND" value="f8f8f2" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_GREEN">
+      <value>
+        <option name="FOREGROUND" value="50fa7b" />
+        <option name="BACKGROUND" value="50fa7b" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_GREEN_BRIGHT">
+      <value>
+        <option name="FOREGROUND" value="69ff94" />
+        <option name="BACKGROUND" value="69ff94" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_MAGENTA">
+      <value>
+        <option name="FOREGROUND" value="ff79c6" />
+        <option name="BACKGROUND" value="ff79c6" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_MAGENTA_BRIGHT">
+      <value>
+        <option name="FOREGROUND" value="ff92df" />
+        <option name="BACKGROUND" value="ff92df" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_RED">
+      <value>
+        <option name="FOREGROUND" value="ff5555" />
+        <option name="BACKGROUND" value="ff5555" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_RED_BRIGHT">
+      <value>
+        <option name="FOREGROUND" value="ff6e6e" />
+        <option name="BACKGROUND" value="ff6e6e" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_WHITE">
+      <value>
+        <option name="FOREGROUND" value="f8f8f2" />
+        <option name="BACKGROUND" value="f8f8f2" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_WHITE_BRIGHT">
+      <value>
+        <option name="FOREGROUND" value="ffffff" />
+        <option name="BACKGROUND" value="ffffff" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_YELLOW">
+      <value>
+        <option name="FOREGROUND" value="f1fa8c" />
+        <option name="BACKGROUND" value="f1fa8c" />
+      </value>
+    </option>
+    <option name="BLOCK_TERMINAL_YELLOW_BRIGHT">
+      <value>
+        <option name="FOREGROUND" value="ffffa5" />
+        <option name="BACKGROUND" value="ffffa5" />
+      </value>
+    </option>
     <option name="BREADCRUMBS_CURRENT">
       <value>
         <option name="FOREGROUND" value="bd93f9" />


### PR DESCRIPTION
Fixes #115.

Adds the palette entries used by the reworked terminal so Dracula and Dracula Colorful render with their expected ANSI colors.

Tested manually in WebStorm 2026.2.1. `verifyPlugin` was not run locally because this machine does not have a JDK installed.